### PR TITLE
China edition: Support for Xiaomi TV Box S 3rd Gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,14 @@ Only needed if running scripts locally outside CI:
 - Java, apktool, zipalign, apksigner
 - ADB (for install.sh)
 
+## Applied patches
+
+| Patch | File | Method | What it does |
+|---|---|---|---|
+| UHD unlock | `DeviceSupportImpl.smali` | `validateIsUhdSupportedDevice()` | Always returns `Pair(true, null)` so 4K streams are served |
+| Quality button | `DiagnosticsPreferenceManagerImpl.smali` | `isVideoQualityEnabled()` | Always returns `true` so the quality selector is visible |
+| Direct-to-view | `RenderAPIConfig.smali` | `getNRPTextureBlitMode()` | Amlogic only (runtime check): bypasses Tiledmedia GPU tile composition, decoder outputs directly to SurfaceView. Fixes ~13% frame drops on Amlogic devices. Other devices use the default rendering path. |
+
 ## License
 
 For personal/educational use only.

--- a/scripts/patch.sh
+++ b/scripts/patch.sh
@@ -220,6 +220,91 @@ else
     warn "DiagnosticsPreferenceManagerImpl.smali not found, skipping quality patch"
 fi
 
+# ─── Patch NRP blit mode to NATIVE_ANDROID_DIRECT_TO_VIEW ──────────────────
+#
+# Tiledmedia's default blit mode (AUTO_DETECT) routes decoded frames through
+# GPU tile composition via SurfaceTexture → EGL → swapBuffers. On Amlogic
+# devices (Xiaomi TV Box S, etc.) this path drops ~13% of frames.
+# The SDK has a built-in NATIVE_ANDROID_DIRECT_TO_VIEW mode that bypasses
+# GPU composition and outputs the decoder directly to the SurfaceView.
+# Fix: on Amlogic devices, return NATIVE_ANDROID_DIRECT_TO_VIEW.
+#      on other devices (NVIDIA Shield, etc.), use the original value.
+
+info "Patching NRP blit mode to direct-to-view (Amlogic only)..."
+RENDER_CONFIG="$(find "${DECOMPILED}" -name 'RenderAPIConfig.smali' -path '*/tiledmedia/*' -print -quit 2>/dev/null || true)"
+
+if [[ -n "${RENDER_CONFIG}" && -f "${RENDER_CONFIG}" ]]; then
+    python3 - "${RENDER_CONFIG}" << 'PYEOF'
+import sys
+
+path = sys.argv[1]
+with open(path, 'r') as f:
+    content = f.read()
+
+# Patch getNRPTextureBlitMode() to return NATIVE_ANDROID_DIRECT_TO_VIEW on Amlogic,
+# or the original configured value on other devices.
+# Original (.locals 1):
+#   iget-object v0, p0, ...->nrpTextureBlitMode
+#   return-object v0
+#
+# Patched (.locals 2):
+#   check Build.HARDWARE.contains("amlogic")
+#   if true -> return NATIVE_ANDROID_DIRECT_TO_VIEW
+#   else   -> return original nrpTextureBlitMode
+
+old = """    iget-object v0, p0, Lcom/tiledmedia/clearvrview/RenderAPIConfig;->nrpTextureBlitMode:Lcom/tiledmedia/clearvrenums/NRPTextureBlitMode;
+
+    return-object v0
+.end method
+
+.method public getNrpColorSpace"""
+
+new = """    sget-object v0, Landroid/os/Build;->HARDWARE:Ljava/lang/String;
+
+    const-string v1, "amlogic"
+
+    invoke-virtual {v0, v1}, Ljava/lang/String;->contains(Ljava/lang/CharSequence;)Z
+
+    move-result v0
+
+    if-eqz v0, :use_default
+
+    sget-object v0, Lcom/tiledmedia/clearvrenums/NRPTextureBlitMode;->NATIVE_ANDROID_DIRECT_TO_VIEW:Lcom/tiledmedia/clearvrenums/NRPTextureBlitMode;
+
+    return-object v0
+
+    :use_default
+    iget-object v0, p0, Lcom/tiledmedia/clearvrview/RenderAPIConfig;->nrpTextureBlitMode:Lcom/tiledmedia/clearvrenums/NRPTextureBlitMode;
+
+    return-object v0
+.end method
+
+.method public getNrpColorSpace"""
+
+if old not in content:
+    print(f"Could not find getNRPTextureBlitMode pattern in {path}", file=sys.stderr)
+    sys.exit(1)
+
+content = content.replace(old, new, 1)
+
+# Also bump .locals 1 to .locals 2 in this method (need v1 for the "amlogic" string)
+method_header = '.method public getNRPTextureBlitMode()Lcom/tiledmedia/clearvrenums/NRPTextureBlitMode;\n    .locals 1'
+method_header_new = '.method public getNRPTextureBlitMode()Lcom/tiledmedia/clearvrenums/NRPTextureBlitMode;\n    .locals 2'
+if method_header in content:
+    content = content.replace(method_header, method_header_new, 1)
+else:
+    print(f"  Warning: could not bump .locals in getNRPTextureBlitMode", file=sys.stderr)
+
+with open(path, 'w') as f:
+    f.write(content)
+print(f"  Patched {path}")
+PYEOF
+
+    [[ $? -eq 0 ]] && ok "NRP direct-to-view patch applied (Amlogic only)" || warn "NRP direct-to-view patch failed"
+else
+    warn "RenderAPIConfig.smali not found, skipping direct-to-view patch"
+fi
+
 # ─── Patch version name ─────────────────────────────────────────────────────
 
 info "Patching version name..."


### PR DESCRIPTION
Note that this change is guarded at runtime to only activate on Amlogic devices.

Tiledmedia's default rendering path (AUTO_DETECT) routes decoded UHD frames through GPU tile composition (SurfaceTexture → EGL → swapBuffers). On Amlogic devices this drops ~13% of frames because the native compositor cannot keep up, causing visible jitter during 4K HDR playback.

The Tiledmedia SDK already has a NATIVE_ANDROID_DIRECT_TO_VIEW mode that outputs decoded frames directly to the SurfaceView, bypassing GPU composition entirely. This patch enables it at runtime on Amlogic devices (checked via Build.HARDWARE), while leaving other devices (NVIDIA Shield, etc.) on the default path.

Tested on Xiaomi TV Box S 3rd Gen (S905X4) — frame drops went from ~13% to <0.1%.