### PR TITLE
Fix newer version

### DIFF
--- a/scripts/patch.sh
+++ b/scripts/patch.sh
@@ -493,13 +493,14 @@ with open(path, 'r') as f:
     content = f.read()
 
 # Replace getDefaultDisplaySize() body with a hardcoded 3840x2160 Point.
+# Preserve its modifiers and support both Context- and Activity-based SDK versions.
 # 0xf00 = 3840, 0x870 = 2160. Result is also cached in trueDisplaySize.
 pattern = (
-    r'\.method private static getDefaultDisplaySize\(Landroid/content/Context;\)Landroid/graphics/Point;'
+    r'(?P<declaration>\.method [^\n]*\bgetDefaultDisplaySize\(Landroid/(?:app/Activity|content/Context);\)Landroid/graphics/Point;)'
     r'.*?'
     r'\.end method'
 )
-replacement = """.method private static getDefaultDisplaySize(Landroid/content/Context;)Landroid/graphics/Point;
+replacement = r"""\g<declaration>
     .locals 3
 
     # UHD Patch: always report a 3840x2160 panel


### PR DESCRIPTION
Fixes:

```
[3](https://github.com/Alexvbp/f1tv-4k-patch/actions/runs/33589233019/job/100119666930#step:23:74)
[*] Searching for TrueTVDisplaySizeHelper.smali...
[+] Found: decompiled/smali_classes8/com/tiledmedia/clearvrview/TrueTVDisplaySizeHelper.smali
[*] Forcing display size to 3840x2160...
ERROR: getDefaultDisplaySize not found
```

since it changed to

```
  Available TrueTVDisplaySizeHelper methods:
    .method static constructor <clinit>()V
    .method public constructor <init>()V
    .method public static getDefaultDisplay(Landroid/app/Activity;)Landroid/view/Display;
    .method private static getDefaultDisplaySize(Landroid/app/Activity;)Landroid/graphics/Point;
    .method private static getDisplaySizeV23(Landroid/view/Display;Landroid/graphics/Point;)V
    .method private static getSystemProperty(Ljava/lang/String;)Ljava/lang/String;
    .method public static getTrueDisplaySizeIfTV(Landroid/app/Activity;Landroid/graphics/Point;)Landroid/graphics/
Point;
    .method public static isTv(Landroid/content/Context;)Z
```

Just installed and checked stream stats and all seems good to me.
